### PR TITLE
Compatibility with deferred asset blocks

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -17,7 +17,6 @@
         {% do assets.addCss('theme://css/main.css', 97) %}
         {% do assets.addCss('theme://css/custom.css', 97) %}
     {% endblock %}
-    {{ assets.css() }}
 
     {% block javascripts %}
         {% do assets.addJs('jquery', 100) %}
@@ -25,7 +24,11 @@
         {% do assets.addJs('theme://js/util.js', 98) %}
         {% do assets.addJs('theme://js/main.js', {'priority':97, 'group':'bottom'}) %}
     {% endblock %}
-    {{ assets.js() }}
+
+    {% block assets %}
+        {{ assets.css() }}
+        {{ assets.js() }}
+    {% endblock %}
 
 {% endblock head%}
 </head>


### PR DESCRIPTION
Brings the theme in line with [this malarkey](https://getgrav.org/blog/important-theme-updates) :)

Base template can be overridden in a derived theme by extending and redeclaring the block as `deferred`, e.g.

```twig
{% extends 'partials/base.html.twig %}

{% block assets deferred %}
  {{ parent() }}
{% endblock %}
```